### PR TITLE
Fixing startup errors with recent version of Space Exploration (0.6)

### DIFF
--- a/TheArcFurnaceImp/changelog.txt
+++ b/TheArcFurnaceImp/changelog.txt
@@ -3,6 +3,7 @@ Version: 1.0.11
 Date: 2022.08.12
   Feature:
     - Added type of furnace in startup settings. Either vanilla furnace-like smelting or selecting recipe like assembling machine.
+    - Added category of smelting of furnace in startup settings. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations.
 
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.10

--- a/TheArcFurnaceImp/changelog.txt
+++ b/TheArcFurnaceImp/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.11
+Date: 2022.08.12
+  Feature:
+    - Added type of furnace in startup settings. Either vanilla furnace-like smelting or selecting recipe like assembling machine.
+
+---------------------------------------------------------------------------------------------------
 Version: 1.0.10
 Date: 2022.08.11
   Info:
@@ -7,6 +13,7 @@ Date: 2022.08.11
     - Fixed startup errors for recipe results when there is a probability and amount_min/max.
     - Fixed copying custom icons for recipes. (If they're used by another mods (such as Deadbolt's stacked recipes), it won't generate a startup error).
     - Fixed entity description.
+
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.9
 Date: 2022.04.13

--- a/TheArcFurnaceImp/changelog.txt
+++ b/TheArcFurnaceImp/changelog.txt
@@ -4,6 +4,7 @@ Date: 2022.08.12
   Feature:
     - Added type of furnace in startup settings. Either vanilla furnace-like smelting or selecting recipe like assembling machine.
     - Added category of smelting of furnace in startup settings. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations. "smelting+kiln" is for both the smelting and kiln category, since kiln was added in Space Exploration 0.6
+    - Added setting to allow in space in startup settings.
 
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.10

--- a/TheArcFurnaceImp/changelog.txt
+++ b/TheArcFurnaceImp/changelog.txt
@@ -3,7 +3,7 @@ Version: 1.0.11
 Date: 2022.08.12
   Feature:
     - Added type of furnace in startup settings. Either vanilla furnace-like smelting or selecting recipe like assembling machine.
-    - Added category of smelting of furnace in startup settings. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations.
+    - Added category of smelting of furnace in startup settings. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations. "smelting+kiln" is for both the smelting and kiln category, since kiln was added in Space Exploration 0.6
 
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.10

--- a/TheArcFurnaceImp/changelog.txt
+++ b/TheArcFurnaceImp/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.10
+Date: 2022.08.11
+  Info:
+    - Added stdlib (Factorio Standard Library) as requirement for the bugfixes.
+  Bugfix:
+    - Fixed startup errors for recipe results when there is a probability and amount_min/max.
+    - Fixed copying custom icons for recipes. (If they're used by another mods (such as Deadbolt's stacked recipes), it won't generate a startup error).
+---------------------------------------------------------------------------------------------------
 Version: 1.0.9
 Date: 2022.04.13
   Bugfix:

--- a/TheArcFurnaceImp/changelog.txt
+++ b/TheArcFurnaceImp/changelog.txt
@@ -6,6 +6,7 @@ Date: 2022.08.11
   Bugfix:
     - Fixed startup errors for recipe results when there is a probability and amount_min/max.
     - Fixed copying custom icons for recipes. (If they're used by another mods (such as Deadbolt's stacked recipes), it won't generate a startup error).
+    - Fixed entity description.
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.9
 Date: 2022.04.13

--- a/TheArcFurnaceImp/changelog.txt
+++ b/TheArcFurnaceImp/changelog.txt
@@ -5,6 +5,7 @@ Date: 2022.08.12
     - Added type of furnace in startup settings. Either vanilla furnace-like smelting or selecting recipe like assembling machine.
     - Added category of smelting of furnace in startup settings. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations. "smelting+kiln" is for both the smelting and kiln category, since kiln was added in Space Exploration 0.6
     - Added setting to allow in space in startup settings.
+    - Added fluid inputs/outputs for the Arc Furnace.
 
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.10

--- a/TheArcFurnaceImp/data-updates.lua
+++ b/TheArcFurnaceImp/data-updates.lua
@@ -56,8 +56,11 @@ local function scale_recipe(recipe, scale)
             for idx, rspec in pairs(recipe["results"]) do
                 if rspec["amount"] ~= nil then
                     recipe["results"][idx]["amount"] = rspec["amount"] * scale
-                else -- Contains a result with probability
+                end
+                if rspec["amount_min"] ~= nil then
                     recipe["results"][idx]["amount_min"] = rspec["amount_min"] * scale
+                end
+                if rspec["amount_max"] ~= nil then
                     recipe["results"][idx]["amount_max"] = rspec["amount_max"] * scale
                 end
             end

--- a/TheArcFurnaceImp/data-updates.lua
+++ b/TheArcFurnaceImp/data-updates.lua
@@ -1,4 +1,5 @@
 local utils_table = require('__stdlib__/stdlib/utils/table')
+local furnace_crafting_category = settings.startup["ArcFurnace-crafting-category"].value
 
 local function mimic_recipe_module_limitations(source_recipe, target_recipe)
     for _, module in pairs(data.raw["module"]) do
@@ -91,8 +92,10 @@ end
 
 
 -- Generate smelting recipes
-for _, recipe in pairs(data.raw["recipe"]) do
-    if recipe["category"] == "smelting" then
-        generate_arc_smelting_recipe(recipe)
+if furnace_crafting_category == "arc-smelting" then
+    for _, recipe in pairs(data.raw["recipe"]) do
+        if recipe["category"] == "smelting" then
+            generate_arc_smelting_recipe(recipe)
+        end
     end
 end

--- a/TheArcFurnaceImp/data-updates.lua
+++ b/TheArcFurnaceImp/data-updates.lua
@@ -74,6 +74,12 @@ local function generate_arc_smelting_recipe(original_recipe)
     recipe["name"] = "arc-" .. original_recipe["name"]
     recipe["category"] = "arc-smelting"
     --Enable all recipes, since I do not know how to enable it after the specific research has been activated (like when enriched ores tech from Krastorio is unlocked)
+    if type(recipe["normal"]) == "table" then
+        recipe["normal"]["enabled"] = true
+    end
+    if type(recipe["expensive"]) == "table" then
+        recipe["expensive"]["enabled"] = true
+    end
     recipe["enabled"] = true 
 
     local scaling_factor = 10

--- a/TheArcFurnaceImp/data-updates.lua
+++ b/TheArcFurnaceImp/data-updates.lua
@@ -1,65 +1,4 @@
-local function copy_recipe_data(src, dst, scale)
-    -- does this recipe have "normal" or "expensive" variants?
-    -- If so, the recipe data is actually in those tables.
-    -- (... if they are tables - they can be false if the recipe is to be disabled in that mode).
-    if src["normal"] ~= nil or src["expensive"] ~= nil then
-        if type(src["normal"]) == "table" then
-            dst["normal"] = {}
-            copy_recipe_data(src["normal"], dst["normal"], scale)
-        else
-            dst["normal"] = src["normal"]
-        end
-    
-        if type(src["expensive"]) == "table" then
-            dst["expensive"] = {}
-            copy_recipe_data(src["expensive"], dst["expensive"], scale)
-        else
-            dst["expensive"] = src["expensive"]
-        end
-    else
-        dst["ingredients"] = {}
-        for idx, ispec in pairs(src["ingredients"]) do
-            -- Ingredient prototypes exist in two flavours: array-like and map-like.
-            if #ispec > 1 then
-                dst["ingredients"][idx] = {
-                    ispec[1],
-                    ispec[2] * scale
-                }
-            else
-                dst["ingredients"][idx] = {
-                    ["type"] = ispec["type"],
-                    ["name"] = ispec["name"],
-                    ["amount"] = ispec["amount"] * scale,
-                    ["catalyst_amount"] = (ispec["catalyst_amount"] or 0) * scale,
-                    ["temperture"] = ispec["temperature"],
-                    ["minimum_temperture"] = ispec["minimum_temperature"],
-                    ["maximum_temperture"] = ispec["maximum_temperature"],
-                    ["fluidbox_index"] = ispec["fluidbox_index"]
-                }
-            end
-        end
-
-        dst["energy_required"] = src["energy_required"]
-
-        if src["result"] ~= nil then
-            dst["result"] = src["result"]
-            dst["result_count"] = (src["result_count"] or 1) * scale
-        end
-
-        if src["results"] ~= nil then
-            dst["results"] = {}
-            for idx, rspec in pairs(src["results"]) do
-                dst["results"][idx] = {
-                    ["type"] = rspec["type"],
-                    ["name"] = rspec["name"],
-                    ["amount"] = rspec["amount"] * scale,
-                    ["temperture"] = rspec["temperature"]
-                }
-            end
-        end
-    end
-end
-
+local utils_table = require('__stdlib__/stdlib/utils/table')
 
 local function mimic_recipe_module_limitations(source_recipe, target_recipe)
     for _, module in pairs(data.raw["module"]) do
@@ -83,19 +22,63 @@ local function mimic_recipe_module_limitations(source_recipe, target_recipe)
     end
 end
 
+local function scale_recipe(recipe, scale)
+    if recipe["normal"] ~= nil or recipe["expensive"] ~= nil then
+        if type(recipe["normal"]) == "table" then
+            scale_recipe(recipe["normal"], scale)
+        end
+    
+        if type(recipe["expensive"]) == "table" then
+            scale_recipe(recipe["expensive"], scale)
+        end
+    else
+        for idx, ispec in pairs(recipe["ingredients"]) do
+            -- Ingredient prototypes exist in two flavours: array-like and map-like.
+            if #ispec > 1 then
+                recipe["ingredients"][idx] = {
+                    ispec[1],
+                    ispec[2] * scale
+                }
+            else
+                recipe["ingredients"][idx]["amount"] = ispec["amount"] * scale
+                if recipe["ingredients"][idx]["catalyst_amount"] ~= nil then
+                    recipe["ingredients"][idx]["catalyst_amount"] = ispec["catalyst_amount"] * scale
+                end
+            end
+        end
+        
+        if recipe["result"] ~= nil then
+            recipe["result_count"] = (recipe["result_count"] or 1) * scale
+        end
+
+        if recipe["results"] ~= nil then
+            for idx, rspec in pairs(recipe["results"]) do
+                if rspec["amount"] ~= nil then
+                    recipe["results"][idx]["amount"] = rspec["amount"] * scale
+                else -- Contains a result with probability
+                    recipe["results"][idx]["amount_min"] = rspec["amount_min"] * scale
+                    recipe["results"][idx]["amount_max"] = rspec["amount_max"] * scale
+                end
+            end
+        end
+    end
+end
 
 local function generate_arc_smelting_recipe(original_recipe)
     if original_recipe["category"] ~= "smelting" then
         return
     end
 
-    recipe = {
-        ["type"] = "recipe",
-        ["name"] = "arc-" .. original_recipe["name"],
-        ["category"] = "arc-smelting",
-    }
+    recipe = utils_table.deep_copy(original_recipe)
 
-    copy_recipe_data(original_recipe, recipe, 10)
+    recipe["name"] = "arc-" .. original_recipe["name"]
+    recipe["category"] = "arc-smelting"
+    --Enable all recipes, since I do not know how to enable it after the specific research has been activated (like when enriched ores tech from Krastorio is unlocked)
+    recipe["enabled"] = true 
+
+    local scaling_factor = 10
+    scale_recipe(recipe, scaling_factor)
+
     data:extend({recipe})
     mimic_recipe_module_limitations(original_recipe["name"], recipe["name"])
 end

--- a/TheArcFurnaceImp/data.lua
+++ b/TheArcFurnaceImp/data.lua
@@ -1,4 +1,5 @@
 local MOD_ROOT = "__TheArcFurnaceImp__"
+local furnace_type = settings.startup["ArcFurnace-type"].value
 
 data:extend({
 	-- Tech Tree Recipe
@@ -47,7 +48,7 @@ data:extend({
         stack_size = 50
 	},
 	{
-        type = "furnace",
+        type = furnace_type,
         name = "arc-furnace",
         icon = MOD_ROOT .. "/graphics/hr-arc-furnace-square.png",
         icon_size = 357,

--- a/TheArcFurnaceImp/data.lua
+++ b/TheArcFurnaceImp/data.lua
@@ -16,42 +16,64 @@ if furnace_crafting_category == "smelting+kiln" then
 else
     furnace_crafting_category = {furnace_crafting_category}
 end
-
-local fluid_boxes =
-{
+local fluid_boxes
+if furnace_type == "furnace" then
+    fluid_boxes =
     {
-        production_type = "input",
-        pipe_covers = pipecoverspictures(),
-        base_area = 10,
-        base_level = -1,
-        pipe_connections = {{ type="input", position = {-1.5, 6.8} }},
-        secondary_draw_orders = { north = -1 }
-    },
-    {
-        production_type = "input",
-        pipe_covers = pipecoverspictures(),
-        base_area = 10,
-        base_level = -1,
-        pipe_connections = {{ type="input", position = {1.5, 6.8} }},
-        secondary_draw_orders = { north = -1 }
-    },
-    {
-        production_type = "output",
-        pipe_covers = pipecoverspictures(),
-        base_area = 10,
-        base_level = 1,
-        pipe_connections = {{ type="output", position = {-4.5, 6.8} }},
-        secondary_draw_orders = { north = -1 }
-    },
-    {
-        production_type = "output",
-        pipe_covers = pipecoverspictures(),
-        base_area = 10,
-        base_level = 1,
-        pipe_connections = {{ type="output", position = {4.5, 6.8} }},
-        secondary_draw_orders = { north = -1 }
+        {
+            production_type = "input",
+            pipe_covers = pipecoverspictures(),
+            base_area = 10,
+            base_level = -1,
+            pipe_connections = {{ type="input", position = {-1.5, 6.8} }},
+            secondary_draw_orders = { north = -1 }
+        },
+        {
+            production_type = "output",
+            pipe_covers = pipecoverspictures(),
+            base_area = 10,
+            base_level = 1,
+            pipe_connections = {{ type="output", position = {1.5, 6.8} }},
+            secondary_draw_orders = { north = -1 }
+        }
     }
-}
+else
+    fluid_boxes =
+    {
+        {
+            production_type = "input",
+            pipe_covers = pipecoverspictures(),
+            base_area = 10,
+            base_level = -1,
+            pipe_connections = {{ type="input", position = {-1.5, 6.8} }},
+            secondary_draw_orders = { north = -1 }
+        },
+        {
+            production_type = "input",
+            pipe_covers = pipecoverspictures(),
+            base_area = 10,
+            base_level = -1,
+            pipe_connections = {{ type="input", position = {1.5, 6.8} }},
+            secondary_draw_orders = { north = -1 }
+        },
+        {
+            production_type = "output",
+            pipe_covers = pipecoverspictures(),
+            base_area = 10,
+            base_level = 1,
+            pipe_connections = {{ type="output", position = {-4.5, 6.8} }},
+            secondary_draw_orders = { north = -1 }
+        },
+        {
+            production_type = "output",
+            pipe_covers = pipecoverspictures(),
+            base_area = 10,
+            base_level = 1,
+            pipe_connections = {{ type="output", position = {4.5, 6.8} }},
+            secondary_draw_orders = { north = -1 }
+        }
+    }
+end
 
 data:extend({
 	-- Tech Tree Recipe

--- a/TheArcFurnaceImp/data.lua
+++ b/TheArcFurnaceImp/data.lua
@@ -1,6 +1,7 @@
 local MOD_ROOT = "__TheArcFurnaceImp__"
 local furnace_type = settings.startup["ArcFurnace-type"].value
 local furnace_crafting_category = settings.startup["ArcFurnace-crafting-category"].value
+local furnace_allow_in_space = settings.startup["ArcFurnace-space-platform"].value
 
 if furnace_crafting_category == "smelting+kiln" then
     -- Check if space exploration >= 0.6 is there for the kiln crafting category.
@@ -86,6 +87,7 @@ data:extend({
         crafting_speed = settings.startup["ArcFurnace-CraftingSpeed"].value,
         energy_usage = "100000kW",
         source_inventory_size = 1,
+        se_allow_in_space = furnace_allow_in_space,
         energy_source = {
             type = "electric",
             usage_priority = "secondary-input",

--- a/TheArcFurnaceImp/data.lua
+++ b/TheArcFurnaceImp/data.lua
@@ -17,6 +17,42 @@ else
     furnace_crafting_category = {furnace_crafting_category}
 end
 
+local fluid_boxes =
+{
+    {
+        production_type = "input",
+        pipe_covers = pipecoverspictures(),
+        base_area = 10,
+        base_level = -1,
+        pipe_connections = {{ type="input", position = {-1.5, 6.8} }},
+        secondary_draw_orders = { north = -1 }
+    },
+    {
+        production_type = "input",
+        pipe_covers = pipecoverspictures(),
+        base_area = 10,
+        base_level = -1,
+        pipe_connections = {{ type="input", position = {1.5, 6.8} }},
+        secondary_draw_orders = { north = -1 }
+    },
+    {
+        production_type = "output",
+        pipe_covers = pipecoverspictures(),
+        base_area = 10,
+        base_level = 1,
+        pipe_connections = {{ type="output", position = {-4.5, 6.8} }},
+        secondary_draw_orders = { north = -1 }
+    },
+    {
+        production_type = "output",
+        pipe_covers = pipecoverspictures(),
+        base_area = 10,
+        base_level = 1,
+        pipe_connections = {{ type="output", position = {4.5, 6.8} }},
+        secondary_draw_orders = { north = -1 }
+    }
+}
+
 data:extend({
 	-- Tech Tree Recipe
     {
@@ -77,6 +113,7 @@ data:extend({
         collision_box = {{-10, -2.8}, {10, 6.3}},
         selection_box = {{-10, -2.8}, {10, 6.3}},
         drawing_box   = {{-10, -2.8}, {10, 6.3}},
+        fluid_boxes = fluid_boxes,
         module_specification = {
             module_slots = 8,
             module_info_icon_shift = {0, 0.8}

--- a/TheArcFurnaceImp/data.lua
+++ b/TheArcFurnaceImp/data.lua
@@ -2,6 +2,20 @@ local MOD_ROOT = "__TheArcFurnaceImp__"
 local furnace_type = settings.startup["ArcFurnace-type"].value
 local furnace_crafting_category = settings.startup["ArcFurnace-crafting-category"].value
 
+if furnace_crafting_category == "smelting+kiln" then
+    -- Check if space exploration >= 0.6 is there for the kiln crafting category.
+    if mods["space-exploration"] ~= nil then
+        local major, minor, patch = string.match(mods["space-exploration"], "(%d+)%.(%d+)%.(%d+)")
+        if (tonumber(major) == 0 and tonumber(minor) >= 6) or (tonumber(major) >= 1) then
+            furnace_crafting_category = {"smelting", "kiln"}
+        else
+            furnace_crafting_category = {"smelting"}
+        end
+    end
+else
+    furnace_crafting_category = {furnace_crafting_category}
+end
+
 data:extend({
 	-- Tech Tree Recipe
     {
@@ -67,7 +81,7 @@ data:extend({
             module_info_icon_shift = {0, 0.8}
         },
         allowed_effects = {"consumption", "speed", "productivity", "pollution"},
-        crafting_categories = {furnace_crafting_category},
+        crafting_categories = furnace_crafting_category,
         result_inventory_size = 2,
         crafting_speed = settings.startup["ArcFurnace-CraftingSpeed"].value,
         energy_usage = "100000kW",

--- a/TheArcFurnaceImp/data.lua
+++ b/TheArcFurnaceImp/data.lua
@@ -1,5 +1,6 @@
 local MOD_ROOT = "__TheArcFurnaceImp__"
 local furnace_type = settings.startup["ArcFurnace-type"].value
+local furnace_crafting_category = settings.startup["ArcFurnace-crafting-category"].value
 
 data:extend({
 	-- Tech Tree Recipe
@@ -66,7 +67,7 @@ data:extend({
             module_info_icon_shift = {0, 0.8}
         },
         allowed_effects = {"consumption", "speed", "productivity", "pollution"},
-        crafting_categories = {"arc-smelting"},
+        crafting_categories = {furnace_crafting_category},
         result_inventory_size = 2,
         crafting_speed = settings.startup["ArcFurnace-CraftingSpeed"].value,
         energy_usage = "100000kW",

--- a/TheArcFurnaceImp/info.json
+++ b/TheArcFurnaceImp/info.json
@@ -5,7 +5,7 @@
     "author": "SingularityCat",
     "homepage": "https://github.com/SingularityCat/factorio-arc-furnace",
     "description": "Ores cower in fear from this furnace, watch as it drinks electricity to turn solid ore into liquid within an instant.",
-    "factorio_version": "1.1"
+    "factorio_version": "1.1",
     "dependencies": [
         "stdlib >= 0.0.6"
     ]

--- a/TheArcFurnaceImp/info.json
+++ b/TheArcFurnaceImp/info.json
@@ -1,6 +1,6 @@
 {
     "name": "TheArcFurnaceImp",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "title": "Arc Furnace (Improved)",
     "author": "SingularityCat",
     "homepage": "https://github.com/SingularityCat/factorio-arc-furnace",

--- a/TheArcFurnaceImp/info.json
+++ b/TheArcFurnaceImp/info.json
@@ -1,9 +1,12 @@
 {
     "name": "TheArcFurnaceImp",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "title": "Arc Furnace (Improved)",
     "author": "SingularityCat",
     "homepage": "https://github.com/SingularityCat/factorio-arc-furnace",
     "description": "Ores cower in fear from this furnace, watch as it drinks electricity to turn solid ore into liquid within an instant.",
     "factorio_version": "1.1"
+    "dependencies": [
+        "stdlib >= 0.0.6"
+    ]
 }

--- a/TheArcFurnaceImp/info.json
+++ b/TheArcFurnaceImp/info.json
@@ -8,5 +8,6 @@
     "factorio_version": "1.1",
     "dependencies": [
         "stdlib >= 0.0.6"
+        "? space-exploration >= 0.6.0"
     ]
 }

--- a/TheArcFurnaceImp/info.json
+++ b/TheArcFurnaceImp/info.json
@@ -7,7 +7,7 @@
     "description": "Ores cower in fear from this furnace, watch as it drinks electricity to turn solid ore into liquid within an instant.",
     "factorio_version": "1.1",
     "dependencies": [
-        "stdlib >= 0.0.6"
+        "stdlib >= 0.0.6",
         "? space-exploration >= 0.6.0"
     ]
 }

--- a/TheArcFurnaceImp/locale/en/config.cfg
+++ b/TheArcFurnaceImp/locale/en/config.cfg
@@ -1,6 +1,9 @@
 [entity-name]
 arc-furnace=Arc Furnace
-	
+
+[entity-description]
+arc-furnace=A furnace that rapidly smelt ore into plates.
+
 [technology-name]
 arc-furnace=Arc Furnace
 

--- a/TheArcFurnaceImp/locale/en/config.cfg
+++ b/TheArcFurnaceImp/locale/en/config.cfg
@@ -14,6 +14,8 @@ arc-furnace=I hope your power grid can support this beast.
 
 [mod-setting-name]
 ArcFurnace-CraftingSpeed=Crafting speed
+ArcFurnace-type=Type
 [mod-setting-description]
 ArcFurnace-CraftingSpeed=Default is 80, decrease to slow down, increase to speed up.
+ArcFurnace-Type=Default is "furnace". Vanilla furnace-like smelting or selecting recipe like assembling machine.
 

--- a/TheArcFurnaceImp/locale/en/config.cfg
+++ b/TheArcFurnaceImp/locale/en/config.cfg
@@ -19,5 +19,5 @@ ArcFurnace-crafting-category=Crafting category
 [mod-setting-description]
 ArcFurnace-CraftingSpeed=Default is 80, decrease to slow down, increase to speed up.
 ArcFurnace-type=Default is "furnace". Vanilla furnace-like smelting or selecting recipe like assembling machine.
-ArcFurnace-crafting-category=Default is "arc-smelting". Change the crafting category of the arc furnace. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations.
+ArcFurnace-crafting-category=Default is "arc-smelting". Change the crafting category of the arc furnace. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations. "smelting+kiln" is for both the smelting and kiln category, since kiln was added in Space Exploration 0.6
 

--- a/TheArcFurnaceImp/locale/en/config.cfg
+++ b/TheArcFurnaceImp/locale/en/config.cfg
@@ -15,7 +15,9 @@ arc-furnace=I hope your power grid can support this beast.
 [mod-setting-name]
 ArcFurnace-CraftingSpeed=Crafting speed
 ArcFurnace-type=Type
+ArcFurnace-crafting-category=Crafting category
 [mod-setting-description]
 ArcFurnace-CraftingSpeed=Default is 80, decrease to slow down, increase to speed up.
-ArcFurnace-Type=Default is "furnace". Vanilla furnace-like smelting or selecting recipe like assembling machine.
+ArcFurnace-type=Default is "furnace". Vanilla furnace-like smelting or selecting recipe like assembling machine.
+ArcFurnace-crafting-category=Default is "arc-smelting". Change the crafting category of the arc furnace. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations.
 

--- a/TheArcFurnaceImp/locale/en/config.cfg
+++ b/TheArcFurnaceImp/locale/en/config.cfg
@@ -16,8 +16,11 @@ arc-furnace=I hope your power grid can support this beast.
 ArcFurnace-CraftingSpeed=Crafting speed
 ArcFurnace-type=Type
 ArcFurnace-crafting-category=Crafting category
+ArcFurnace-space-platform=Allow in space?
+
 [mod-setting-description]
 ArcFurnace-CraftingSpeed=Default is 80, decrease to slow down, increase to speed up.
 ArcFurnace-type=Default is "furnace". Vanilla furnace-like smelting or selecting recipe like assembling machine.
 ArcFurnace-crafting-category=Default is "arc-smelting". Change the crafting category of the arc furnace. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations. "smelting+kiln" is for both the smelting and kiln category, since kiln was added in Space Exploration 0.6
+ArcFurnace-space-platform=Default is false. Allow the Arc Furnace in space?
 

--- a/TheArcFurnaceImp/settings.lua
+++ b/TheArcFurnaceImp/settings.lua
@@ -12,15 +12,19 @@ data:extend({
         name = "ArcFurnace-type",
         setting_type = "startup",
         default_value = "furnace",
-        allowed_values = {"assembling-machine", "furnace"},
-        order = "a"
+        allowed_values = {"assembling-machine", "furnace"}
     },
     {
         type = "string-setting",
         name = "ArcFurnace-crafting-category",
         setting_type = "startup",
         default_value = "arc-smelting",
-        allowed_values = {"smelting", "arc-smelting", "smelting+kiln"},
-        order = "a"
+        allowed_values = {"smelting", "arc-smelting", "smelting+kiln"}
+    },
+    {
+        type = "bool-setting",
+        name = "ArcFurnace-space-platform",
+        setting_type = "startup",
+        default_value = false
     }
 })

--- a/TheArcFurnaceImp/settings.lua
+++ b/TheArcFurnaceImp/settings.lua
@@ -6,5 +6,13 @@ data:extend({
         default_value = 100,
         minimum_value = 0.1,
         maximum_value = 200
+    },
+    {
+        type = "string-setting",
+        name = "ArcFurnace-type",
+        setting_type = "startup",
+        default_value = "furnace",
+        allowed_values = {"assembling-machine", "furnace"},
+        order = "a"
     }
 })

--- a/TheArcFurnaceImp/settings.lua
+++ b/TheArcFurnaceImp/settings.lua
@@ -20,7 +20,7 @@ data:extend({
         name = "ArcFurnace-crafting-category",
         setting_type = "startup",
         default_value = "arc-smelting",
-        allowed_values = {"smelting", "arc-smelting"},
+        allowed_values = {"smelting", "arc-smelting", "smelting+kiln"},
         order = "a"
     }
 })

--- a/TheArcFurnaceImp/settings.lua
+++ b/TheArcFurnaceImp/settings.lua
@@ -14,5 +14,13 @@ data:extend({
         default_value = "furnace",
         allowed_values = {"assembling-machine", "furnace"},
         order = "a"
+    },
+    {
+        type = "string-setting",
+        name = "ArcFurnace-crafting-category",
+        setting_type = "startup",
+        default_value = "arc-smelting",
+        allowed_values = {"smelting", "arc-smelting"},
+        order = "a"
     }
 })


### PR DESCRIPTION
I've refactored the way recipes are copied and scaled, this should be more reliable and also save extra information such as custom icons. However, this add a new dependency: stdlib ([Factorio Standard Library](https://mods.factorio.com/mod/stdlib)).
I've also fixed the entity description.
This also adds the following features:
    - Added type of furnace in startup settings. Either vanilla furnace-like smelting or selecting recipe like assembling machine.
    - Added category of smelting of furnace in startup settings. "arc-smelting" creates scaled recipe for the arc furnace and "smelting" doesn't. However, when chosing "smelting", due to the limitations of the game engine, it is recommended to use a mod such as "Deadlock Stacked Recipes" to circumvent those game engine limitations. "smelting+kiln" is for both the smelting and kiln category, since kiln was added in Space Exploration 0.6
    - Added setting to allow in space in startup settings.
    - Added fluid inputs/outputs for the Arc Furnace.